### PR TITLE
Allow column visibility to be configured on the whole group.

### DIFF
--- a/scripts/jtoxkit.js
+++ b/scripts/jtoxkit.js
@@ -403,7 +403,7 @@ window.jT.ui = {
             // Allow bVisible to be set on the whole category
             if (!ccLib.isNull(catCol.bVisible)) {
               catCol[name] = catCol[name] || {};
-              catCol[name].bVisible = (ccLib.isNull(catCol[name].bVisible) || catCol[name].bVisible) && !!catCol.bVisible;
+              catCol[name].bVisible = !!catCol[name].bVisible || !!catCol.bVisible;
             }
   	        catCol = catCol[name];
           }

--- a/scripts/jtoxkit.js
+++ b/scripts/jtoxkit.js
@@ -398,12 +398,19 @@ window.jT.ui = {
 	    var catCol = kit.settings.configuration.columns[cat];
 	    if (!ccLib.isNull(catCol)) {
 	      if (!!group) {
-	        catCol = catCol[group];
-  	      if (!ccLib.isNull(catCol))
+          catCol = catCol[group];
+  	      if (!ccLib.isNull(catCol)){
+            // Allow bVisible to be set on the whole category
+            if (!ccLib.isNull(catCol.bVisible)) {
+              catCol[name] = catCol[name] || {};
+              catCol[name].bVisible = (ccLib.isNull(catCol[name].bVisible) || catCol[name].bVisible) && !!catCol.bVisible;
+            }
   	        catCol = catCol[name];
+          }
         }
-        else
+        else {
 	        catCol = catCol[name];
+        }
 	    }
 
 	    if (ccLib.isNull(catCol))

--- a/toxstudy.html
+++ b/toxstudy.html
@@ -44,7 +44,7 @@
             "reliability": {"mRender": function (data, type, full) { return data.r_value.replace(/\s*\([^)]*\)/gi, ''); }}
       		},
           "parameters": {
-            "bVisible": false
+            "bVisible": true
           }
       	},
       	"PC_PARTITION_SECTION": {

--- a/toxstudy.html
+++ b/toxstudy.html
@@ -42,7 +42,10 @@
       		"protocol": {
       		  "citation": { "bVisible": false },
             "reliability": {"mRender": function (data, type, full) { return data.r_value.replace(/\s*\([^)]*\)/gi, ''); }}
-      		}
+      		},
+          "parameters": {
+            "bVisible": false
+          }
       	},
       	"PC_PARTITION_SECTION": {
       		"effects": {

--- a/www/jtoxkit.js
+++ b/www/jtoxkit.js
@@ -827,7 +827,7 @@ window.jT.ui = {
             // Allow bVisible to be set on the whole category
             if (!ccLib.isNull(catCol.bVisible)) {
               catCol[name] = catCol[name] || {};
-              catCol[name].bVisible = (ccLib.isNull(catCol[name].bVisible) || catCol[name].bVisible) && !!catCol.bVisible;
+              catCol[name].bVisible = !!catCol[name].bVisible || !!catCol.bVisible;
             }
   	        catCol = catCol[name];
           }

--- a/www/jtoxkit.js
+++ b/www/jtoxkit.js
@@ -822,12 +822,19 @@ window.jT.ui = {
 	    var catCol = kit.settings.configuration.columns[cat];
 	    if (!ccLib.isNull(catCol)) {
 	      if (!!group) {
-	        catCol = catCol[group];
-  	      if (!ccLib.isNull(catCol))
+          catCol = catCol[group];
+  	      if (!ccLib.isNull(catCol)){
+            // Allow bVisible to be set on the whole category
+            if (!ccLib.isNull(catCol.bVisible)) {
+              catCol[name] = catCol[name] || {};
+              catCol[name].bVisible = (ccLib.isNull(catCol[name].bVisible) || catCol[name].bVisible) && !!catCol.bVisible;
+            }
   	        catCol = catCol[name];
+          }
         }
-        else
+        else {
 	        catCol = catCol[name];
+        }
 	    }
 
 	    if (ccLib.isNull(catCol))

--- a/www/jtoxkit.min.js
+++ b/www/jtoxkit.min.js
@@ -128,10 +128,9 @@ return res;},changeTabsIds:function(root,suffix){jT.$('ul li a',root).each(funct
 return;var li=document.createElement('li');var a=document.createElement('a');li.appendChild(a);a.href='#'+id;a.innerHTML=name;jT.$('ul',root)[0].appendChild(li);if(typeof content=='function')
 content=content(root);else if(typeof content=='string'){var div=document.createElement('div');div.innerHTML=content;content=div;}
 content.id=id;root.appendChild(content);$(root).tabs('refresh');return{'tab':a,'content':content};},modifyColDef:function(kit,col,category,group){if(col.sTitle===undefined||col.sTitle==null)
-return null;var name=col.sTitle.toLowerCase();var getColDef=function(cat){var catCol=kit.settings.configuration.columns[cat];if(!ccLib.isNull(catCol)){if(!!group){catCol=catCol[group];if(!ccLib.isNull(catCol))
-catCol=catCol[name];}
-else
-catCol=catCol[name];}
+return null;var name=col.sTitle.toLowerCase();var getColDef=function(cat){var catCol=kit.settings.configuration.columns[cat];if(!ccLib.isNull(catCol)){if(!!group){catCol=catCol[group];if(!ccLib.isNull(catCol)){if(!ccLib.isNull(catCol.bVisible)){catCol[name]=catCol[name]||{};catCol[name].bVisible=(ccLib.isNull(catCol[name].bVisible)||catCol[name].bVisible)&&!!catCol.bVisible;}
+catCol=catCol[name];}}
+else{catCol=catCol[name];}}
 if(ccLib.isNull(catCol))
 catCol={};return catCol;};col=jT.$.extend(col,(!!group?getColDef('_'):{}),getColDef(category));return ccLib.isNull(col.bVisible)||col.bVisible?col:null;},sortColDefs:function(colDefs){for(var i=0,l=colDefs.length;i<l;++i)
 colDefs[i].iNaturalOrder=i;colDefs.sort(function(a,b){var res=(a.iOrder||0)-(b.iOrder||0);if(res==0)

--- a/www/jtoxkit.min.js
+++ b/www/jtoxkit.min.js
@@ -128,7 +128,7 @@ return res;},changeTabsIds:function(root,suffix){jT.$('ul li a',root).each(funct
 return;var li=document.createElement('li');var a=document.createElement('a');li.appendChild(a);a.href='#'+id;a.innerHTML=name;jT.$('ul',root)[0].appendChild(li);if(typeof content=='function')
 content=content(root);else if(typeof content=='string'){var div=document.createElement('div');div.innerHTML=content;content=div;}
 content.id=id;root.appendChild(content);$(root).tabs('refresh');return{'tab':a,'content':content};},modifyColDef:function(kit,col,category,group){if(col.sTitle===undefined||col.sTitle==null)
-return null;var name=col.sTitle.toLowerCase();var getColDef=function(cat){var catCol=kit.settings.configuration.columns[cat];if(!ccLib.isNull(catCol)){if(!!group){catCol=catCol[group];if(!ccLib.isNull(catCol)){if(!ccLib.isNull(catCol.bVisible)){catCol[name]=catCol[name]||{};catCol[name].bVisible=(ccLib.isNull(catCol[name].bVisible)||catCol[name].bVisible)&&!!catCol.bVisible;}
+return null;var name=col.sTitle.toLowerCase();var getColDef=function(cat){var catCol=kit.settings.configuration.columns[cat];if(!ccLib.isNull(catCol)){if(!!group){catCol=catCol[group];if(!ccLib.isNull(catCol)){if(!ccLib.isNull(catCol.bVisible)){catCol[name]=catCol[name]||{};catCol[name].bVisible=!!catCol[name].bVisible||!!catCol.bVisible;}
 catCol=catCol[name];}}
 else{catCol=catCol[name];}}
 if(ccLib.isNull(catCol))


### PR DESCRIPTION
The visibility of columns can be configured for the whole group at once, globally on "_" category, or per category. Works on all groups, not just parameters. Example:
```
      "columns": {
        "_": {
          "parameters": {
            "bVisible": false
          }
      	},
      	"PC_PARTITION_SECTION": {
          "parameters": {
            "bVisible": true
          }
      	}
```

Closes #142