### PR TITLE
Add XLSX export icon to defaults in toxcompound.js.

### DIFF
--- a/scripts/toxcompound.js
+++ b/scripts/toxcompound.js
@@ -97,7 +97,8 @@ var jToxCompound = (function () {
         {type: "text/x-arff", icon: "images/arff.png"},
         {type: "text/x-arff-3col", icon: "images/arff-3.png"},
         {type: "application/rdf+xml", icon: "images/rdf64.png"},
-        {type: "application/json", icon: "images/json64.png"}
+        {type: "application/json", icon: "images/json64.png"},
+        {type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", icon: "images/xlsx.png"}
       ],
 
       // These are instance-wide pre-definitions of default baseFeatures as described below.


### PR DESCRIPTION
The icon must be uploaded to the server, icons are not part of the repository (or I can't find them).
The PNG version of the icon:
![xlsx](https://cloud.githubusercontent.com/assets/827958/8856256/53787e08-3172-11e5-9af8-eb6d3dad6856.png)

Should be enough to close #141 but the server is returning RDF instead of XLSX for content type `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`
