### PR TITLE
Ketcher location fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/png
+libs/voronoi-treemaps*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
-[submodule "ketcher"]
-	path = ketcher
+[submodule "libs/ketcher"]
+	path = libs/ketcher
 	url = https://github.com/thejonan/ketcher.git
-	branch = master


### PR DESCRIPTION
Ketcher submodule was erroneously moved to the root, it should stay in _libs_ subfolder. This commit does so.